### PR TITLE
Added dumb sleep to allow VM to fully boot.

### DIFF
--- a/tests/test_vmware.py
+++ b/tests/test_vmware.py
@@ -79,7 +79,7 @@ class TestVMware(unittest.TestCase):
         with self.assertRaises(ValueError):
             vmware.delete_avamar(username='bob', machine_name='myOtherAvamarBox', logger=fake_logger)
 
-    @patch.object(vmware, '_block_on_vmware_tools')
+    @patch.object(vmware, '_block_on_boot')
     @patch.object(vmware, '_configure_network')
     @patch.object(vmware.virtual_machine, 'set_meta')
     @patch.object(vmware, 'Ova')
@@ -88,7 +88,7 @@ class TestVMware(unittest.TestCase):
     @patch.object(vmware, 'consume_task')
     @patch.object(vmware, 'vCenter')
     def test_create_avamar(self, fake_vCenter, fake_consume_task, fake_deploy_from_ova, fake_get_info,
-                           fake_Ova, fake_set_meta, fake__configure_network, fake_block_on_vmware_tools):
+                           fake_Ova, fake_set_meta, fake__configure_network, fake_block_on_boot):
         """``create_avamar`` returns a dictionary upon success"""
         fake_logger = MagicMock()
         fake_deploy_from_ova.return_value.name = 'myAvamar'
@@ -179,15 +179,17 @@ class TestVMware(unittest.TestCase):
         self.assertTrue(fake_consume_task.called)
 
     @patch.object(vmware.time, 'sleep')
-    def test_block_on_vmware_tools(self, fake_sleep):
-        """``_block_on_vmware_tools`` waits for VMware Tools to be ready"""
+    def test_block_on_boot(self, fake_sleep):
+        """``_block_on_boot`` waits for VMware Tools to be ready"""
         the_vm = MagicMock()
         toolsStatus = PropertyMock(side_effect=['notready', vmware.vim.vm.GuestInfo.ToolsStatus.toolsOk])
         type(the_vm.guest).toolsStatus = toolsStatus
 
-        vmware._block_on_vmware_tools(the_vm)
+        vmware._block_on_boot(the_vm)
 
-        self.assertTrue(fake_sleep.called)
+        # 2 calls to sleep - 1 when VMware Tools is not ready, then a second
+        # to continue blocking in hopes that the VM completes booting.
+        self.assertEqual(2, fake_sleep.call_count)
 
 
 


### PR DESCRIPTION
I thought this was a quirk with VMware tools when initially debugging. Turns out, nope! Some `init` service in Avamar reset the network config if the VM isn't allowed to fully boot. Blocking on just VMware tools wasn't enough; watching the boot screen (fun, right) I saw VMware tools start, then *a pile* of other things, and after about 2-3 minutes the screen was at the login prompt. Hopefully the 5 minute dumb sleep is enough to avoid fallout from this race condition. Only time will tell 😅!